### PR TITLE
Refactor and test service loader

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -17,7 +17,7 @@ var loginCommand = &cobra.Command{
 	Short: "Log in on external service",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(command *cobra.Command, args []string) error {
-		serviceLoader := new(services.DefaultServiceLoader)
+		serviceLoader := new(services.MapServiceLoader)
 		return Login(serviceLoader, command.OutOrStdout(), args)
 	},
 }

--- a/commands/login.go
+++ b/commands/login.go
@@ -17,8 +17,7 @@ var loginCommand = &cobra.Command{
 	Short: "Log in on external service",
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(command *cobra.Command, args []string) error {
-		serviceLoader := new(services.MapServiceLoader)
-		return Login(serviceLoader, command.OutOrStdout(), args)
+		return Login(services.AvailableServices, command.OutOrStdout(), args)
 	},
 }
 

--- a/services/loader.go
+++ b/services/loader.go
@@ -2,12 +2,7 @@
 
 package services
 
-import (
-	"fmt"
-
-	"github.com/dietrichm/admirer/services/lastfm"
-	"github.com/dietrichm/admirer/services/spotify"
-)
+import "fmt"
 
 // ServiceLoader loads service instances by name.
 type ServiceLoader interface {
@@ -15,17 +10,15 @@ type ServiceLoader interface {
 }
 
 // MapServiceLoader loads actual instances of services.
-type MapServiceLoader struct{}
+type MapServiceLoader map[string]func() (Service, error)
 
 // ForName returns service instance for service name.
-func (d *MapServiceLoader) ForName(serviceName string) (service Service, err error) {
-	switch serviceName {
-	case "spotify":
-		service, err = spotify.NewSpotify()
-	case "lastfm":
-		service, err = lastfm.NewLastfm()
-	default:
-		err = fmt.Errorf("unknown service %q", serviceName)
+func (m MapServiceLoader) ForName(serviceName string) (service Service, err error) {
+	loader, exists := m[serviceName]
+
+	if !exists {
+		return nil, fmt.Errorf("unknown service %q", serviceName)
 	}
-	return
+
+	return loader()
 }

--- a/services/loader.go
+++ b/services/loader.go
@@ -14,11 +14,11 @@ type ServiceLoader interface {
 	ForName(serviceName string) (Service, error)
 }
 
-// DefaultServiceLoader loads actual instances of services.
-type DefaultServiceLoader struct{}
+// MapServiceLoader loads actual instances of services.
+type MapServiceLoader struct{}
 
 // ForName returns service instance for service name.
-func (d *DefaultServiceLoader) ForName(serviceName string) (service Service, err error) {
+func (d *MapServiceLoader) ForName(serviceName string) (service Service, err error) {
 	switch serviceName {
 	case "spotify":
 		service, err = spotify.NewSpotify()

--- a/services/loader_test.go
+++ b/services/loader_test.go
@@ -1,0 +1,33 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/dietrichm/admirer/services/spotify"
+)
+
+func TestMapServiceLoader(t *testing.T) {
+	t.Run("returns service when loader exists", func(t *testing.T) {
+		service := &spotify.Spotify{}
+
+		serviceLoader := MapServiceLoader{
+			"foo": func() (Service, error) {
+				return service, nil
+			},
+			"bar": func() (Service, error) {
+				return nil, nil
+			},
+		}
+
+		expected := service
+		got, err := serviceLoader.ForName("foo")
+
+		if got != expected {
+			t.Errorf("expected %q, got %q", expected, got)
+		}
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+}

--- a/services/loader_test.go
+++ b/services/loader_test.go
@@ -30,4 +30,29 @@ func TestMapServiceLoader(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 	})
+
+	t.Run("returns error when loader does not exist", func(t *testing.T) {
+		serviceLoader := MapServiceLoader{
+			"foo": func() (Service, error) {
+				return nil, nil
+			},
+		}
+
+		service, err := serviceLoader.ForName("bar")
+
+		if service != nil {
+			t.Errorf("Unexpected service instance: %v", service)
+		}
+
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+
+		expected := `unknown service "bar"`
+		got := err.Error()
+
+		if got != expected {
+			t.Errorf("expected %q, got %q", expected, got)
+		}
+	})
 }

--- a/services/loader_test.go
+++ b/services/loader_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/dietrichm/admirer/services/spotify"
@@ -53,6 +54,29 @@ func TestMapServiceLoader(t *testing.T) {
 
 		if got != expected {
 			t.Errorf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("returns error when loader yields error", func(t *testing.T) {
+		serviceError := errors.New("service error")
+		serviceLoader := MapServiceLoader{
+			"foo": func() (Service, error) {
+				return nil, serviceError
+			},
+		}
+
+		service, err := serviceLoader.ForName("foo")
+
+		if service != nil {
+			t.Errorf("Unexpected service instance: %v", service)
+		}
+
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+
+		if err != serviceError {
+			t.Errorf("expected %q, got %q", serviceError, err)
 		}
 	})
 }

--- a/services/services.go
+++ b/services/services.go
@@ -2,10 +2,25 @@
 
 package services
 
+import (
+	"github.com/dietrichm/admirer/services/lastfm"
+	"github.com/dietrichm/admirer/services/spotify"
+)
+
 // Service is the external service interface.
 type Service interface {
 	Name() string
 	CreateAuthURL() string
 	Authenticate(code string) error
 	GetUsername() (string, error)
+}
+
+// AvailableServices is the configured ServiceLoader for the available services.
+var AvailableServices = MapServiceLoader{
+	"spotify": func() (Service, error) {
+		return spotify.NewSpotify()
+	},
+	"lastfm": func() (Service, error) {
+		return lastfm.NewLastfm()
+	},
 }


### PR DESCRIPTION
With some refactoring it's possible to test the service loader.

Note we are creating an actual `Spotify` service struct in the test because our current package design for mocks disallows loading the mock package there. This would introduce an import cycle.

Let's redesign the mock packages first before switching to an actual mock.